### PR TITLE
feat(firestore): Fixing Firestore emulator tests

### DIFF
--- a/Firestore/tests/Snippet/FieldValueTest.php
+++ b/Firestore/tests/Snippet/FieldValueTest.php
@@ -41,7 +41,9 @@ class FieldValueTest extends SnippetTestCase
         $this->checkAndSkipGrpcTests();
 
         $this->connection = $this->prophesize(ConnectionInterface::class);
-        $this->firestore = TestHelpers::stub(FirestoreClient::class);
+        $this->firestore = TestHelpers::stub(FirestoreClient::class, [
+            ['projectId' => 'my-awesome-project'],
+        ]);
     }
 
     public function testDeleteField()
@@ -51,16 +53,16 @@ class FieldValueTest extends SnippetTestCase
             "writes" => [
                 [
                     "updateMask" => [
-                        "fieldPaths" => ["hometown"]
+                        "fieldPaths" => ["hometown"],
                     ],
                     "currentDocument" => [
-                        "exists" => true
+                        "exists" => true,
                     ],
                     "update" => [
                         "name" => "projects/my-awesome-project/databases/(default)/documents/users/dave",
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ])->willReturn([[]]);
 
         $this->firestore->___setProperty('connection', $this->connection->reveal());
@@ -83,15 +85,15 @@ class FieldValueTest extends SnippetTestCase
                         "fieldTransforms" => [
                             [
                                 "fieldPath" => "lastLogin",
-                                "setToServerValue" => ServerValue::REQUEST_TIME
-                            ]
-                        ]
+                                "setToServerValue" => ServerValue::REQUEST_TIME,
+                            ],
+                        ],
                     ],
                     "currentDocument" => [
-                        "exists" => true
-                    ]
-                ]
-            ]
+                        "exists" => true,
+                    ],
+                ],
+            ],
         ])->willReturn([[]]);
 
         $this->firestore->___setProperty('connection', $this->connection->reveal());
@@ -117,20 +119,20 @@ class FieldValueTest extends SnippetTestCase
                                 'appendMissingElements' => [
                                     'values' => [
                                         [
-                                            'stringValue' => 'red'
+                                            'stringValue' => 'red',
                                         ], [
-                                            'stringValue' => 'blue'
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
+                                            'stringValue' => 'blue',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
                     ],
                     "currentDocument" => [
-                        "exists" => true
-                    ]
-                ]
-            ]
+                        "exists" => true,
+                    ],
+                ],
+            ],
         ])->willReturn([[]]);
 
         $this->firestore->___setProperty('connection', $this->connection->reveal());
@@ -156,18 +158,18 @@ class FieldValueTest extends SnippetTestCase
                                 'removeAllFromArray' => [
                                     'values' => [
                                         [
-                                            'stringValue' => 'green'
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
+                                            'stringValue' => 'green',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
                     ],
                     "currentDocument" => [
-                        "exists" => true
-                    ]
-                ]
-            ]
+                        "exists" => true,
+                    ],
+                ],
+            ],
         ])->willReturn([[]]);
 
         $this->firestore->___setProperty('connection', $this->connection->reveal());
@@ -191,16 +193,16 @@ class FieldValueTest extends SnippetTestCase
                             [
                                 "fieldPath" => "loginCount",
                                 'increment' => [
-                                    'integerValue' => 1
-                                ]
-                            ]
-                        ]
+                                    'integerValue' => 1,
+                                ],
+                            ],
+                        ],
                     ],
                     "currentDocument" => [
-                        "exists" => true
-                    ]
-                ]
-            ]
+                        "exists" => true,
+                    ],
+                ],
+            ],
         ])->willReturn([[]]);
 
         $this->firestore->___setProperty('connection', $this->connection->reveal());


### PR DESCRIPTION
Firestore emulator tests are failing currently with following error:

```
Google\Cloud\Firestore\Tests\Snippet\FieldValueTest::testDeleteField
TypeError: Google\Cloud\Firestore\DocumentReference::writeResult(): Argument #1 ($commitResponse) must be of type array, null given, called in /usr/local/google/home/vishwarajanand/github/google-cloud-php/Firestore/src/DocumentReference.php on line 302

/usr/local/google/home/vishwarajanand/github/google-cloud-php/Firestore/src/DocumentReference.php:427
/usr/local/google/home/vishwarajanand/github/google-cloud-php/Firestore/src/DocumentReference.php:302
/usr/local/google/home/vishwarajanand/github/google-cloud-php/Firestore/vendor/google/cloud-core/src/Testing/Snippet/Parser/Snippet.php:167
/usr/local/google/home/vishwarajanand/github/google-cloud-php/Firestore/vendor/google/cloud-core/src/Testing/Snippet/Parser/Snippet.php:177
/usr/local/google/home/vishwarajanand/github/google-cloud-php/Firestore/tests/Snippet/FieldValueTest.php:75
```
reason being FirestoreClient gets `emulator-project` as the default project rather than `my-awesome-project`, [ref code pointer](https://github.com/googleapis/google-cloud-php/blob/main/Firestore/src/FirestoreClient.php#L153).