### PR TITLE
fix(storage): seeking object before file creation

### DIFF
--- a/Storage/src/StorageObject.php
+++ b/Storage/src/StorageObject.php
@@ -611,10 +611,11 @@ class StorageObject
      */
     public function downloadToFile($path, array $options = [])
     {
+        $source = $this->downloadAsStream($options);
         $destination = Utils::streamFor(fopen($path, 'w'));
 
         Utils::copyToStream(
-            $this->downloadAsStream($options),
+            $source,
             $destination
         );
 


### PR DESCRIPTION
Addresses : https://github.com/googleapis/google-cloud-php/issues/3347

## Change:
Moving object seek before file creation while downloading a storage object.

## Test:

Directly edited the `/vendor` folder in `php-docs-samples` and validated that:

1. File is created while object is present
`php src/download_public_file.php $GOOGLE_STORAGE_BUCKET sample.txt ./temp.txt` 

2. No file is created when object is not present (previously an empty file was being created)
`php src/download_public_file.php $GOOGLE_STORAGE_BUCKET no_sample.txt ./temp.txt`

**Note:** 
In test case 2, with or without this change, an exception is thrown.