### PR TITLE
chore(Compute): fix System tests

### DIFF
--- a/Compute/tests/System/V1/PaginationTest.php
+++ b/Compute/tests/System/V1/PaginationTest.php
@@ -80,7 +80,9 @@ class PaginationTest extends TestCase
         $nextPage = $page->getNextPage(1);
         $content = iterator_to_array($page->getIterator());
         $nextContent = iterator_to_array($nextPage->getIterator());
-        self::assertNotEquals($content, $nextContent);
+        self::assertCount(1, $content);
+        self::assertCount(1, $nextContent);
+        self::assertNotEquals($content[0]->getId(), $nextContent[0]->getid());
     }
 
     public function  testNextPageSize()
@@ -165,9 +167,13 @@ class PaginationTest extends TestCase
         );
         $page = $response->getPage();
         $nextPage = $page->getNextPage(1);
-        $content = iterator_to_array($page->getIterator());
-        $nextContent = iterator_to_array($nextPage->getIterator());
-        self::assertNotEquals($content, $nextContent);
+        $content = $this->getInstancesFromAggregatedPage($page);
+        $nextContent = $this->getInstancesFromAggregatedPage($nextPage);
+
+        self::assertNotEquals(
+            current($content)->getId(),
+            current($nextContent)->getid()
+        );
     }
 
     public function  testAggregatedNextPageSize()
@@ -178,11 +184,7 @@ class PaginationTest extends TestCase
         );
         $page = $response->getPage();
         $nextPage = $page->getNextPage(2);
-        $nextContent = [];
-        foreach ($nextPage->getIterator() as $zone => $instancesList) {
-            $pageResults = iterator_to_array($instancesList->getInstances());
-            $nextContent = array_merge($nextContent, $pageResults);
-        }
+        $nextContent = $this->getInstancesFromAggregatedPage($nextPage);
         self::assertCount(2, $nextContent);
     }
 
@@ -193,11 +195,17 @@ class PaginationTest extends TestCase
             ['maxResults' => 3]
         );
         $page = $response->getPage();
-        $allResults = [];
-        foreach ($page->getIterator() as $zone => $instancesList) {
-            $zoneResults = iterator_to_array($instancesList->getInstances());
-            $allResults = array_merge($allResults, $zoneResults);
-        }
+        $allResults = $this->getInstancesFromAggregatedPage($page);
         self::assertCount(3, $allResults);
+    }
+
+    private function getInstancesFromAggregatedPage($page)
+    {
+        $results = [];
+        foreach ($page->getIterator() as $zone => $instancesList) {
+            $pageResults = iterator_to_array($instancesList->getInstances());
+            $results = array_merge($results, $pageResults);
+      }
+      return $results;
     }
 }


### PR DESCRIPTION
Currently, System tests are failing for Compute. 

## Change
1. `testNextPage` asserts on non-equality of two objects, but it's both coming from same memory address (weird behavior for protobuf objects). So, migrating to asserting on `getId(..)` function return value instead.
2. `testAggregatedNextPage` seems to have a bug where it loads all aggregated instances rather than asserting on just the page. Created `getInstancesFromAggregatedPage` helper function to extract page values from response.
3. removed dup code and used `getInstancesFromAggregatedPage` in other tests too

## Test
Tests are dependent on GCP account to have atleast four instances to query pages of instances. After creating them in my account, I can see tests pass as below:

```
google-cloud-php/Compute % vendor/bin/phpunit -c phpunit-system.xml.dist tests/System/V1/PaginationTest.php
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

..........                                                        10 / 10 (100%)

Time: 1.09 minutes, Memory: 10.00 MB

OK (10 tests, 12 assertions)
google-cloud-php/Compute %
```

ref: [b/265168087](http://b/265168087)