### PR TITLE
chore: reduce setup php time by removing gRPC pinning

### DIFF
--- a/.github/workflows/firestore-emulator-system-tests.yaml
+++ b/.github/workflows/firestore-emulator-system-tests.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           php-version: '7.4'
           tools: pecl
-          extensions: grpc-1.49.0
+          extensions: grpc
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Test PR