### PR TITLE
chore: test missing label checker

### DIFF
--- a/.github/workflows/incorrect-conventional-commit-check.yaml
+++ b/.github/workflows/incorrect-conventional-commit-check.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           repository: ${{ github.repository }}
       - name: "Check for an incorrect feat label in the PR"
-        if: ${{ github.event.pull_request.user.login == 'gcf-owl-bot' && !startsWith(github.event.pull_request.title, 'feat')}}
+        if: ${{ github.event.pull_request.user.login == 'vishwarajanand' && !startsWith(github.event.pull_request.title, 'feat')}}
         # OwlBot PRs which are not labelled feat should not add new files or methods
         continue-on-error: true
         run: |

--- a/.github/workflows/incorrect-conventional-commit-check.yaml
+++ b/.github/workflows/incorrect-conventional-commit-check.yaml
@@ -1,7 +1,8 @@
 name: Incorrect Conventional Commit Check
 on:
   pull_request:
-    branches: ['main']
+    types: [opened, synchronize, reopened, edited]
+
 jobs:
   # More info at https://github.com/Roave/BackwardCompatibilityCheck.
   incorrect-conventional-commit-check:
@@ -28,4 +29,4 @@ jobs:
         run: |
           ~/.composer/vendor/bin/roave-backward-compatibility-check \
               --from=origin/main \
-              --to=${{ steps.latest-release.outputs.release }} --format=github-actions
+              --to=${{ github.event.pull_request.head.sha }} --format=github-actions

--- a/.github/workflows/incorrect-conventional-commit-check.yaml
+++ b/.github/workflows/incorrect-conventional-commit-check.yaml
@@ -17,13 +17,12 @@ jobs:
       - name: "Install dependencies"
         run: composer global require "roave/backward-compatibility-check:^8.2"
       - name: Get Latest Release
-        if: github.event.pull_request.user.login == 'release-please[bot]'
         id: latest-release
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: ${{ github.repository }}
       - name: "Check for an incorrect feat label in the PR"
-        if: ${{ github.event.pull_request.user.login == 'gcf-owl-bot' && startsWith(github.event.pull_request.title, 'feat')}}
+        if: ${{ github.event.pull_request.user.login == 'gcf-owl-bot' && !startsWith(github.event.pull_request.title, 'feat')}}
         # OwlBot PRs which are not labelled feat should not add new files or methods
         continue-on-error: true
         run: |

--- a/Firestore/src/FirestoreClient.php
+++ b/Firestore/src/FirestoreClient.php
@@ -160,6 +160,14 @@ class FirestoreClient
     }
 
     /**
+     * Todo: Remove before committing to main.
+     */
+    public function myCustomFunction()
+    {
+        print('Do NOT commit to main.');
+    }
+
+    /**
      * Get a Batch Writer
      *
      * The {@see Google\Cloud\Firestore\WriteBatch} allows more performant


### PR DESCRIPTION
This is a test PR for : 

## Test setup - 1
1. Added `incorrect-conventional-commit-check.yaml` which checks PRs which are NOT `feat` against `main` for any function/method additions.
2. As part of c7c361ce223523faf982a0712002e4d92129c5e0, added a new function `FirestoreClient::myCustomFunction` which should fail this check.

## Expected Result:
`Incorrect Conventional Commit Check` GH action should trigger and fail after doing a BC check.

## Test setup - 2
1. Rename the PR as feat, should pass the check.
2. Remove the function `FirestoreClient::myCustomFunction` which should also pass this check.

## Expected Result:
`Incorrect Conventional Commit Check` GH action should re-trigger and pass after doing a BC check.
